### PR TITLE
Moved the load_settings line down so it will run upon command launch

### DIFF
--- a/SublimeHostsEdit.py
+++ b/SublimeHostsEdit.py
@@ -1,7 +1,6 @@
 import sublime, sublime_plugin
 
-settings = sublime.load_settings('SublimeHostsEdit.sublime-settings')
-
 class OpenHostsFileCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
+		settings = sublime.load_settings('SublimeHostsEdit.sublime-settings')
 		self.view.window().open_file(settings.get(sublime.platform()+'_hosts_file_location'))


### PR DESCRIPTION
Using ST3: your plugin would run fine after loading but would fail after a restart of ST. 
I'm not sure if this is the best fix for this, but it does work!
re: https://github.com/martinssipenko/SublimeHostsEdit/issues/3
