### PR TITLE
Menu option, fixed JSON config file, added JSON versions for tmLanguage and tmPreference

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,5 +1,16 @@
 [
     {
+        "caption": "Tools",
+        "id": "tools",
+        "children":
+        [
+            {
+                "command": "open_hosts_file",
+                "caption": "Open Hosts File"
+            }
+        ]
+    },
+    {
         "caption": "Preferences",
         "mnemonic": "n",
         "id": "preferences",

--- a/SublimeHostsEdit.sublime-settings
+++ b/SublimeHostsEdit.sublime-settings
@@ -1,5 +1,4 @@
 {
-   //PATH to `hosts` file depending on system
    "windows_hosts_file_location": "C:/Windows/System32/drivers/etc/hosts",
    "linux_hosts_file_location": "/etc/hosts",
    "osx_hosts_file_location": "/private/etc/hosts"

--- a/syntax/Comments.JSON-tmPreferences
+++ b/syntax/Comments.JSON-tmPreferences
@@ -1,0 +1,13 @@
+{
+	"name": "Comments",
+	"scope": "source.hosts-config",
+	"settings": {
+		"shellVariables": [
+			{
+				"name": "TM_COMMENT_START",
+				"value": "# "
+			}
+		]
+	},
+	"uuid": "E6CBDBA3-30DC-4EBD-B4DD-2527FBEED52A"
+}

--- a/syntax/Host Config.JSON-tmLanguage
+++ b/syntax/Host Config.JSON-tmLanguage
@@ -1,0 +1,23 @@
+{
+    "fileTypes": [
+        "hosts"
+    ], 
+    "name": "Hosts Config", 
+    "patterns": [
+        {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.comment.source.hosts-config"
+                }
+            }, 
+            "name": "comment.line.number-sign.source.hosts-config", 
+            "match": "(#).*$\\n?"
+        }, 
+        {
+            "name": "constant.source.hosts-config", 
+            "match": "^[\\d|\\.]+"
+        }
+    ],
+    "scopeName": "source.hosts-config",
+    "uuid": "783C4FE3-EF25-41F2-9AF4-B6094E9927A2"
+}

--- a/syntax/Host Config.tmLanguage
+++ b/syntax/Host Config.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>


### PR DESCRIPTION
- I added a new menu item under 'Tools' to open the hosts file.
- The SublimeHostsEdit.sublime-settings contained a comment which is not valid JSON
- Added Added JSON versions for tmPreference and tmLanguage files for easy modification
  I also re-build the tmLanguage file from JSON to include correct DOCTYPE.
